### PR TITLE
Get the latest PSReadLine module installed

### DIFF
--- a/PowerShellEditorServices.build.ps1
+++ b/PowerShellEditorServices.build.ps1
@@ -309,6 +309,25 @@ task RestorePsesModules -After Build {
 
         Save-Module @splatParameters
     }
+
+    # TODO: Replace this with adding a new module to Save when a new PSReadLine release comes out to the Gallery
+    if (-not (Test-Path $PSScriptRoot/module/PSReadLine))
+    {
+        Write-Host "`tInstalling module: PSReadLine"
+
+        # Download AppVeyor zip
+        $jobId = (Invoke-RestMethod https://ci.appveyor.com/api/projects/lzybkr/PSReadLine).build.jobs[0].jobId
+        Invoke-RestMethod https://ci.appveyor.com/api/buildjobs/$jobId/artifacts/bin%2FRelease%2FPSReadLine.zip -OutFile $PSScriptRoot/module/PSRL
+
+        # Position PSReadLine
+        Expand-Archive $PSScriptRoot/module/PSRL.zip $PSScriptRoot/module/PSRL
+        Move-Item $PSScriptRoot/module/PSRL/PSReadLine $PSScriptRoot/module
+
+        # Clean up
+        Remove-Item -Force -Recurse $PSScriptRoot/module/PSRL.zip
+        Remove-Item -Force -Recurse $PSScriptRoot/module/PSRL
+    }
+
     Write-Host "`n"
 }
 

--- a/src/PowerShellEditorServices/Session/PSReadLinePromptContext.cs
+++ b/src/PowerShellEditorServices/Session/PSReadLinePromptContext.cs
@@ -29,8 +29,8 @@ namespace Microsoft.PowerShell.EditorServices.Session {
             [System.Diagnostics.DebuggerStepThrough()]
             param()
             end {
-                $module = Get-Module -ListAvailable PSReadLine | Select-Object -First 1
-                if (-not $module -or $module.Version -lt ([version]'2.0.0')) {
+                $module = Get-Module -ListAvailable PSReadLine | Where-Object Version -ge '2.0.0' | Sort-Object -Descending Version | Select-Object -First 1
+                if (-not $module) {
                     return
                 }
 


### PR DESCRIPTION
It turns out that `Get-Module -ListAvailable` lists modules not in module path order, but in hashcode order (i.e. totally randomly). (Related to https://github.com/PowerShell/PowerShell/issues/7020).

So rather than loading a random PSRL, we should try and get the latest one.

Ideally we would test if the `PSConsoleReadLine` type loaded for a given PSReadLine import provides the APIs we expect, but hopefully with the next release that will be encoded with the version number.
